### PR TITLE
Adds Receiver & Transmitter recipes to Crafting Table

### DIFF
--- a/src/main/resources/data/wirelessredstone/recipes/receiver.json
+++ b/src/main/resources/data/wirelessredstone/recipes/receiver.json
@@ -1,0 +1,27 @@
+{
+  "group": "wirelessredstone",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "TRT",
+    "SSS",
+    "III"
+  ],
+  "key": {
+    "T": {
+      "item": "minecraft:redstone_torch"
+    },
+    "R": {
+      "item": "minecraft:redstone"
+    },
+    "S": {
+      "item": "minecraft:stone"
+    },
+    "I": {
+      "item": "minecraft:iron_ingot"
+    }
+  },
+  "result": {
+    "item": "wirelessredstone:receiver",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/wirelessredstone/recipes/transmitter.json
+++ b/src/main/resources/data/wirelessredstone/recipes/transmitter.json
@@ -1,0 +1,27 @@
+{
+  "group": "wirelessredstone",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " T ",
+    "SRS",
+    "III"
+  ],
+  "key": {
+    "T": {
+      "item": "minecraft:redstone_torch"
+    },
+    "R": {
+      "item": "minecraft:redstone"
+    },
+    "S": {
+      "item": "minecraft:stone"
+    },
+    "I": {
+      "item": "minecraft:iron_ingot"
+    }
+  },
+  "result": {
+    "item": "wirelessredstone:transmitter",
+    "count": 1
+  }
+}


### PR DESCRIPTION
**This PR does the following:**

Creates a(n) sub-directory under ``..resources/data/wirelessredstone/recipes``.

Creates two (2) ``{item}.json`` files where ``{item}`` represents a craft-able item.

Groups both recipes under "wirelessredstone".

Implements  receiver (``..resources/data/wirelessredstone/recipes/receiver.json``) recipe.
![Screenshot 2021-07-14 002653](https://user-images.githubusercontent.com/22083307/125561705-f1694503-b6ec-479d-a12a-735bb157c419.png)

Implements  transmitter (``..resources/data/wirelessredstone/recipes/transmitter.json``) recipe.
![Screenshot 2021-07-14 002616](https://user-images.githubusercontent.com/22083307/125561715-33007b40-4233-4cd6-a198-99931bc3d981.png)